### PR TITLE
Add sqlite3worker's git repo url to requirements.text

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,6 @@ jaraco.text==1.6.3
 more-itertools==2.2
 pytz==2016.4
 six==1.10.0
-sqlite3worker==1.0
+git+https://github.com/palantir/sqlite3worker#egg=sqlite3worker
 tempora==1.4
 TinyUrl==0.1.0


### PR DESCRIPTION
the sqlite3worker package is not on pypi.

I'm not sure why, but `pip freeze` shows the req as `sqlite3worker==1.0` - which is not valid and cannot be installed.
